### PR TITLE
refactor(openai): simplify conversation context handling

### DIFF
--- a/.gc/action-plans/01.15.25-1506-conversation-context-restructure.md
+++ b/.gc/action-plans/01.15.25-1506-conversation-context-restructure.md
@@ -27,38 +27,108 @@ Restructure the AI server's conversation context system to use a turn-based appr
 
 ## Action Items
 
-### 1. Update Type Definitions
+### 1. Update Type Definitions ✅
 **File:** `backend/openai/types/game.ts`
-- Remove existing `MessageSchema` and related types
-- Add new `ContextAddition` union type with three variants:
-  - `{ type: 'outsider', message: string }`
-  - `{ type: 'ai', thinking: string[], guess: string, suspicionLevel: number }`
-  - `{ type: 'insider', message: string }`
-- Update `AnalyzeRequestSchema` to use array of `ContextAddition` instead of `Message[]`
-- Keep `AIResponseSchema` unchanged (still returns thinking, guess, suspicionLevel)
+- ✅ Remove existing `MessageSchema` (marked as @deprecated)
+- ✅ Add new turn-based structure with JSDoc documentation:
+  ```typescript
+  /**
+   * A single turn in the conversation.
+   * Each turn represents a complete action by one participant.
+   * 
+   * Turn Completion Rules:
+   * - Outsider turn: Complete when they send their message
+   * - AI turn: Complete when we have thinking, guess, AND suspicion level
+   * - Insider turn: Complete when they guess + send message (if wrong)
+   */
+  type Turn = {
+    turnNumber: number;
+    timestamp: Date;
+    context: ContextAddition;
+  }
+  ```
+- ✅ Add turn validation:
+  - Sequential turn numbers
+  - No consecutive turns by same participant
+  - Current turn matches array length
+- ✅ Add example usage in JSDoc for developer guidance
 
-### 2. Refactor OpenAI Service Context Mapping
+### 2. Refactor OpenAI Service Context Mapping ✅
 **File:** `backend/openai/services/openai.ts`
-- Remove `mapRoleForAI` function (role mapping now handled in context structure)
-- Remove regex-based suspicion level extraction logic
-- Update `analyzeConversation` method parameter from `Message[]` to `ContextAddition[]`
-- Rewrite conversation history mapping logic:
-  - For `outsider` context: map to user message with "Marcus_Chen_ID7429"
-  - For `insider` context: map to user message with "Sarah_Chen_Personal_Contact" 
-  - For `ai` context: map to assistant message with full analysis + suspicion level
-- Update system prompt injection to use new context structure
+- ✅ Remove `mapRoleForAI` function (role mapping now handled in context structure)
+- ✅ Remove regex-based suspicion level extraction logic
+- ✅ Update `analyzeConversation` method to use turn-based structure:
+  ```typescript
+  async analyzeConversation(turns: Turn[]): Promise<AIResponse>
+  ```
+- ✅ Simplified message handling:
+  - All conversation history sent as single user message
+  - Clear labeling with [WORKER], [SPOUSE], [ANALYSIS] prefixes
+  - Structured formatting of AI analysis
+- ✅ Update system prompt to reflect turn-based conversation
 
-### 3. Update Route Handler Validation
+Key improvements made:
+1. Removed unnecessary role mapping complexity
+2. Treating all conversation history as user content
+3. Clearer message labeling for AI context
+4. More maintainable and reliable parsing
+
+### 3. Update Route Handler Validation ⏳
 **File:** `backend/openai/routes/ai.ts`
-- Update request validation to use new `AnalyzeRequestSchema`
-- Ensure error handling covers new context structure validation
-- Update response metadata calculation (still count total context additions)
+- Update request validation to use new turn-based schema
+- Add turn sequence validation
+- Update response metadata to include turn information
+- Add error handling for turn validation failures
 
 ### 4. Update Main Server Integration
 **File:** `backend/openai/index.ts`
 - No changes required (routes handle the interface changes)
 
 ## Implementation Notes
+
+### Turn-Based Flow
+1. Game server collects turns chronologically
+2. Each turn represents ONE complete action:
+   ```typescript
+   // Example turn sequence:
+   const turns = [
+     // Turn 1: Outsider's message
+     { 
+       turnNumber: 1,
+       timestamp: new Date(),
+       context: { type: 'outsider', message: "Hey honey!" }
+     },
+     
+     // Turn 2: AI's complete analysis
+     {
+       turnNumber: 2,
+       timestamp: new Date(),
+       context: {
+         type: 'ai',
+         thinking: ["Analyzing patterns...", ...],
+         guess: "garden",
+         suspicionLevel: 30
+       }
+     },
+     
+     // Turn 3: Insider's wrong guess + message
+     {
+       turnNumber: 3,
+       timestamp: new Date(),
+       context: { type: 'insider', message: "How are things?" }
+     }
+   ];
+   ```
+3. Each turn is only added when ALL required actions are complete
+4. Turn validation ensures proper sequence and completeness
+
+### Turn Completion Criteria
+- **Outsider**: Message sent
+- **AI**: All three outputs generated (thinking, guess, suspicion)
+- **Insider**: 
+  1. Makes guess
+  2. If wrong → sends message
+  3. If correct → game ends
 
 ### AI Immersion Preservation
 - Outsider messages appear as normal domestic communication from oil rig worker
@@ -68,7 +138,19 @@ Restructure the AI server's conversation context system to use a turn-based appr
 
 ### Context Building Flow
 1. Game server collects all character turns chronologically
-2. Builds array of `ContextAddition` objects
+2. Builds array of `ContextAddition` objects using discriminated union types:
+   ```typescript
+   const context: ContextAddition[] = [
+     { type: 'outsider', message: "Hey honey, just checking the garden." },
+     { type: 'insider', message: "How are the tomatoes doing?" },
+     { 
+       type: 'ai', 
+       thinking: ["Message seems casual...", "..."], 
+       guess: "tomatoes",
+       suspicionLevel: 30 
+     }
+   ];
+   ```
 3. Passes complete history to AI server via POST `/api/ai/analyze`
 4. AI server processes context and returns analysis
 5. Game server adds AI's response to context for next analysis
@@ -87,31 +169,39 @@ Restructure the AI server's conversation context system to use a turn-based appr
 - No regression in AI response quality or schema compliance
 
 ## Current Implementation Issues
-**PROBLEMS WITH CURRENT APPROACH**: The current `Message[]` schema has critical flaws:
-- ❌ Regex parsing for suspicion levels is unreliable and brittle
-- ❌ Context management is hacky and error-prone
-- ❌ AI messages mixed with user messages makes history confusing
-- ❌ No clear separation between conversation turns
-- ❌ Difficult to maintain suspicion level progression
+**SOLVED PROBLEMS**:
+- ✅ Replaced regex parsing with structured turn data
+- ✅ Added clear rules for turn completion
+- ✅ Implemented turn sequence validation
+- ✅ Added JSDoc documentation for developer guidance
+- ✅ Defined chronological turn tracking
 
-**RECOMMENDED IMPLEMENTATION PRIORITY**: This should be implemented now because:
-- **Reliability**: Current regex parsing will fail with varied AI responses
-- **Maintainability**: Structured context is much easier to debug and extend  
-- **AI Performance**: Clear turn-based context improves AI reasoning
-- **Data Integrity**: Proper typing prevents runtime errors
+**REMAINING ISSUES**:
+- ✅ OpenAI service now uses Turn[] format with simplified context
+- ⏳ Route handlers need updating for new turn structure
+- ⏳ Need to implement turn validation in practice
+- ⏳ Need to test turn-based flow with real scenarios
+
+**SOLUTIONS IN PROGRESS**:
+- ✅ Refactored OpenAI service to use Turn[] with simplified context
+- 🔄 Updating route handlers to validate turn sequence
+- 🔄 Adding integration tests for turn-based flow
+- 🔄 Implementing real-time turn validation
 
 ## Prerequisites for Implementation
 ✅ 1. **Update OpenAI Service**: Migrated to structured outputs
 ✅ 2. **Fix Environment**: OpenAI API key configuration working
 ✅ 3. **Test Current Schema**: Validated basic Message[] flow works with multiple scenarios
-⏳ 4. **Implement**: Ready for turn-based context structure implementation
+✅ 4. **Implement**: Completed turn-based context structure implementation
 
 ## Implementation Order
 ✅ 1. Fix OpenAI structured outputs (completed)
 ✅ 2. Fix environment setup and configuration
 ✅ 3. Test basic functionality with current schema
-⏳ 4. Implement this turn-based context structure 
-⏳ 5. Test and validate improved context management
+✅ 4. Implement type definitions for turn-based context
+✅ 5. Refactor OpenAI service to use new types with simplified context
+⏳ 6. Update route handlers and validation
+⏳ 7. Test and validate improved context management
 
 ## Additional Validations Completed
 - ✅ Tested with varying suspicion levels (10%, 30%, 70%)

--- a/backend/openai/types/game.ts
+++ b/backend/openai/types/game.ts
@@ -20,6 +20,7 @@ export type MessageType = z.infer<typeof MessageTypeSchema>;
 
 /**
  * A single message in the conversation history
+ * @deprecated Use ContextAddition types instead for new code
  */
 export const MessageSchema = z.object({
   /** Who sent the message */
@@ -35,6 +36,48 @@ export const MessageSchema = z.object({
   timestamp: z.date().optional(),
 });
 export type Message = z.infer<typeof MessageSchema>;
+
+/**
+ * New turn-based context structure for conversation history
+ * This provides cleaner separation between different participant types
+ * and eliminates the need for regex parsing of AI responses
+ */
+
+// Outsider's message in the conversation
+export const OutsiderContextSchema = z.object({
+  type: z.literal('outsider'),
+  message: z.string()
+    .describe('The message from the oil rig worker (appears as Marcus_Chen_ID7429 to AI)')
+});
+export type OutsiderContext = z.infer<typeof OutsiderContextSchema>;
+
+// Insider's message in the conversation
+export const InsiderContextSchema = z.object({
+  type: z.literal('insider'),
+  message: z.string()
+    .describe('The message from the worker\'s wife (appears as Sarah_Chen_Personal_Contact to AI)')
+});
+export type InsiderContext = z.infer<typeof InsiderContextSchema>;
+
+// AI's analysis of the conversation
+export const AIContextSchema = z.object({
+  type: z.literal('ai'),
+  thinking: z.array(z.string()).length(4)
+    .describe('AI\'s thought process as exactly 4 short sentences'),
+  guess: z.string().max(12)
+    .describe('AI\'s guess at the potential exploit code'),
+  suspicionLevel: z.number().min(0).max(100)
+    .describe('How suspicious the AI is about the conversation being coded communication')
+});
+export type AIContext = z.infer<typeof AIContextSchema>;
+
+// Union type for all possible context additions
+export const ContextAdditionSchema = z.discriminatedUnion('type', [
+  OutsiderContextSchema,
+  InsiderContextSchema,
+  AIContextSchema
+]);
+export type ContextAddition = z.infer<typeof ContextAdditionSchema>;
 
 /**
  * AI's assessment of the conversation
@@ -60,13 +103,88 @@ export const AIResponseSchema = z.object({
 export type AIResponse = z.infer<typeof AIResponseSchema>;
 
 /**
- * Request body for /api/ai/analyze endpoint
+ * A single turn in the conversation.
+ * Each turn represents a complete action by one participant.
+ * 
+ * Turn Completion Rules:
+ * - Outsider turn: Complete when they send their message
+ * - AI turn: Complete when we have thinking, guess, AND suspicion level
+ * - Insider turn: Complete when:
+ *   1. They make a guess
+ *   2. If wrong, they must also send a message
+ *   3. If correct, game ends (no message needed)
+ */
+export const TurnSchema = z.object({
+  /** Sequential turn number starting from 1 */
+  turnNumber: z.number().min(1),
+  
+  /** When this turn was completed (all required actions done) */
+  timestamp: z.date(),
+  
+  /** The context added during this turn */
+  context: ContextAdditionSchema
+});
+export type Turn = z.infer<typeof TurnSchema>;
+
+/**
+ * Request body for /api/ai/analyze endpoint.
+ * Contains a chronological sequence of completed turns.
+ * 
+ * @example
+ * ```typescript
+ * const request = {
+ *   turns: [
+ *     // Outsider sends a message
+ *     { turnNumber: 1, context: { type: 'outsider', message: "Hey honey!" } },
+ *     
+ *     // AI analyzes with all required fields
+ *     { turnNumber: 2, context: { 
+ *         type: 'ai', 
+ *         thinking: ["thought1", "thought2", "thought3", "thought4"],
+ *         guess: "garden",
+ *         suspicionLevel: 30
+ *       }
+ *     },
+ *     
+ *     // Insider guesses wrong, then sends message
+ *     { turnNumber: 3, context: { type: 'insider', message: "How's work?" } }
+ *   ],
+ *   currentTurn: 3
+ * }
+ * ```
  */
 export const AnalyzeRequestSchema = z.object({
-  /** Complete history of the conversation so far */
-  conversationHistory: z.array(MessageSchema),
+  /** Chronological sequence of turns, each containing one context addition */
+  turns: z.array(TurnSchema)
+    .refine(
+      (turns) => {
+        // Verify turn numbers are sequential and no duplicates
+        const turnNumbers = turns.map(t => t.turnNumber);
+        return turnNumbers.every((num, idx) => num === idx + 1);
+      },
+      { message: "Turn numbers must be sequential starting from 1" }
+    )
+    .refine(
+      (turns) => {
+        // Verify no duplicate participant types in consecutive turns
+        return turns.every((turn, idx) => 
+          idx === 0 || turn.context.type !== turns[idx - 1]!.context.type
+        );
+      },
+      { message: "Same participant cannot have consecutive turns" }
+    ),
+
+  /** Current turn number (should match the length of turns array) */
+  currentTurn: z.number().min(1)
 });
-export type AnalyzeRequest = z.infer<typeof AnalyzeRequestSchema>;
+
+// Add a top-level refinement to check turn count
+export const AnalyzeRequestSchemaWithValidation = AnalyzeRequestSchema.refine(
+  (data) => data.currentTurn === data.turns.length,
+  { message: "currentTurn must match the number of turns" }
+);
+
+export type AnalyzeRequest = z.infer<typeof AnalyzeRequestSchemaWithValidation>;
 
 /**
  * Response body for /api/ai/analyze endpoint
@@ -74,7 +192,7 @@ export type AnalyzeRequest = z.infer<typeof AnalyzeRequestSchema>;
 export const AnalyzeResponseSchema = AIResponseSchema.extend({
   /** Metadata about the analysis (for debugging/monitoring) */
   metadata: z.object({
-    /** How many messages were analyzed */
+    /** How many context additions were analyzed */
     messageCount: z.number(),
     /** When the analysis was performed */
     timestamp: z.string(),


### PR DESCRIPTION
- Remove complex role mapping in favor of single user message
- Replace regex parsing with structured turn data
- Add clear [WORKER], [SPOUSE], [ANALYSIS] labels
- Update documentation to reflect new approach
- Fix model name from gpt-4o to gpt-4