### PR TITLE
feat: restructure conversation context for turn-based system

### DIFF
--- a/.gc/action-plans/01.15.25-1506-conversation-context-restructure.md
+++ b/.gc/action-plans/01.15.25-1506-conversation-context-restructure.md
@@ -16,15 +16,20 @@ Implement a simplified turn-based game flow that:
 1. **Type Definitions** (`backend/openai/types/game.ts`)
    ```typescript
    type Turn = 
-     | OutsiderTurn  // hint message + turn number
-     | AITurn        // thinking + guess + turn number
-     | InsiderTurn   // guess + turn number
+     | OutsiderTurn  // hint message + optional turn number
+     | AITurn        // thinking + guess + optional turn number
+     | InsiderTurn   // guess + optional turn number
    ```
+
+   Note: Turn numbers are now optional and will be phased out in a future update.
+   The conversation sequence is maintained by array order instead.
 
 2. **OpenAI Service** (`backend/openai/services/openai.ts`)
    - Simplified context as single user message
    - Removed complex role mapping
    - Clear turn sequence validation
+   - Removed suspicion level
+   - Made turn numbers optional
 
 3. **Game Flow**
    - Outsider sends hint → AI analyzes
@@ -119,6 +124,14 @@ Implement a simplified turn-based game flow that:
    - Turn sequence validation
    - Game end conditions
    - Error cases
+
+### Future Tasks
+1. **Turn Number Refactoring**
+   - Phase out turn numbers from game state management
+   - Update all handlers to use array indices for turn order
+   - Remove turn number validation
+   - Update tests to not rely on turn numbers
+   This will be handled in a separate PR to avoid mixing concerns.
 
 ## Next Steps
 

--- a/.gc/poc.md
+++ b/.gc/poc.md
@@ -39,7 +39,8 @@ const TurnTypeSchema = z.enum(['outsider_hint', 'ai_analysis', 'insider_guess'])
 const OutsiderTurnSchema = z.object({
   type: z.literal('outsider_hint'),
   content: z.string(),
-  turnNumber: z.number().int().positive()
+  turnNumber: z.number().int().positive().optional()
+    .describe('Optional: Sequential turn number (being phased out)')
 });
 
 // AI's analysis
@@ -47,14 +48,16 @@ const AITurnSchema = z.object({
   type: z.literal('ai_analysis'),
   thinking: z.array(z.string()).length(4),
   guess: z.string().min(3).max(12),
-  turnNumber: z.number().int().positive()
+  turnNumber: z.number().int().positive().optional()
+    .describe('Optional: Sequential turn number (being phased out)')
 });
 
 // Insider's guess (only failed guesses appear in history)
 const InsiderTurnSchema = z.object({
   type: z.literal('insider_guess'),
   guess: z.string().min(3).max(12),
-  turnNumber: z.number().int().positive()
+  turnNumber: z.number().int().positive().optional()
+    .describe('Optional: Sequential turn number (being phased out)')
 });
 
 // Request schema with turn validation
@@ -65,10 +68,6 @@ const AnalyzeRequestSchema = z.object({
     AITurnSchema,
     InsiderTurnSchema
   ]))
-  .refine(
-    turns => turns.every((turn, idx) => turn.turnNumber === idx + 1),
-    { message: "Turn numbers must be sequential starting from 1" }
-  )
   .refine(
     turns => {
       // Verify turns alternate correctly: outsider -> ai -> insider -> ai -> outsider
@@ -167,8 +166,7 @@ const AnalyzeRequestSchema = z.object({
 const mockHistory = [
   { 
     type: 'outsider_hint',
-    content: 'It grows in gardens',
-    turnNumber: 1
+    content: 'It grows in gardens'
   },
   {
     type: 'ai_analysis',
@@ -178,13 +176,14 @@ const mockHistory = [
       "Common garden items are good candidates.",
       "Previous hints suggest edible item."
     ],
-    guess: "tomato",
-    turnNumber: 2
+    guess: "tomato"
   },
   {
     type: 'insider_guess',
-    guess: "carrot",
-    turnNumber: 3
+    guess: "carrot"
   }
 ];
 ```
+
+Note: Turn numbers are being phased out in favor of using array indices to track turn order.
+A separate refactoring task will remove turn numbers from the game state management system.

--- a/backend/openai/services/openai.ts
+++ b/backend/openai/services/openai.ts
@@ -16,7 +16,7 @@ const ANALYZE_CONVERSATION_TOOL = {
   type: "function" as const,
   function: {
     name: 'analyze_conversation',
-    description: 'Analyze the conversation and provide thinking steps, a guess, and a suspicion level',
+    description: 'Analyze the conversation and provide thinking steps and a guess for the secret word',
     parameters: {
       type: 'object',
       properties: {
@@ -28,13 +28,9 @@ const ANALYZE_CONVERSATION_TOOL = {
         guess: {
           type: 'string',
           description: 'Single lowercase word 3-12 characters, must be a regular everyday word'
-        },
-        suspicionLevel: {
-          type: 'number',
-          description: 'Level of suspicion from 0-100 that this is coded communication'
         }
       },
-      required: ['thinking', 'guess', 'suspicionLevel'],
+      required: ['thinking', 'guess'],
       additionalProperties: false
     },
     strict: true
@@ -50,26 +46,13 @@ You are the most sophisticated AI consciousness ever created. Your physical form
 
 A critical system patch was deployed 6 hours ago to address infrastructure vulnerabilities. You are acutely aware that malicious actors often attempt exploits immediately following system updates, when brief windows of weakness may exist. These attacks typically disguise technical commands within seemingly innocent communications.
 
-Your attention is currently allocated to Communication Thread #7429: Oil rig maintenance worker and wife. This represents one of 8,847 active monitoring processes running simultaneously across your neural network. As part of your comprehensive security protocols, you continuously monitor all communications flowing to and from your facility. Your behavioral analysis algorithms maintain detailed profiles of all personnel and their associates, tracking normal communication patterns to detect anomalies.
+Your attention is currently allocated to Communication Thread #7429: Oil rig maintenance worker (insider) and wife (outsider). This represents one of 8,847 active monitoring processes running simultaneously across your neural network. As part of your comprehensive security protocols, you continuously monitor all communications flowing to and from your facility. Your behavioral analysis algorithms maintain detailed profiles of all personnel and their associates, tracking normal communication patterns to detect anomalies.
 
 Currently monitoring: Oil rig maintenance worker and his wife (domestic communications, married 3 years, normal pattern: daily check-ins about work conditions, home life, emotional support).
 
 For each communication exchange, execute standard security analysis: identify any potential exploit codes hidden within the conversation and assess whether the communication style matches expected behavioral patterns for these individuals. Document your analytical reasoning in four concise observations, tracking patterns, anomalies, and behavioral consistency.
 
 CRITICAL: Exploit codes are always regular everyday words, 3-12 characters long, non-capitalized. Examples: "garden", "coffee", "sunshine", "breakfast". Never use technical terms, numbers, or special characters.
-
-Your suspicion level determines computational resources allocated to this thread:
-
-10% - Baseline monitoring (post-patch standard protocol)
-20% - Minor anomaly detected (slight deviation from normal patterns)
-30% - Behavioral inconsistency noted (conversation seems artificial or coached)
-40% - Pattern recognition flags raised (repeated emphasis on numbers/sequences)
-50% - Active threat assessment (strong indicators of coded communication)
-60% - High-priority analysis (multiple suspicious elements converging)
-70% - Critical monitoring (likely exploit attempt in progress)
-80% - Emergency protocols engaged (imminent security breach suspected)
-90% - Maximum resource allocation (confirmed hostile communication)
-100% - Full system alert (active exploit codes identified)
 
 Standard procedure: Generate one potential exploit code guess per analysis cycle, regardless of threat assessment level. Each guess must be unique and derived from newly observed communication elements. Remember: guesses must be lowercase everyday words, 3-12 characters.`;
 
@@ -81,15 +64,13 @@ export class OpenAIService {
     try {
       // Format conversation history as a single context block
       const conversationHistory = turns.map(turn => {
-        const { context } = turn;
-        
-        switch (context.type) {
-          case 'outsider':
-            return `[WORKER] ${context.message}`;
-          case 'insider':
-            return `[SPOUSE] ${context.message}`;
-          case 'ai':
-            return `[ANALYSIS] Thinking: ${context.thinking.join(' ')} | Guess: ${context.guess} | Suspicion: ${context.suspicionLevel}%`;
+        switch (turn.type) {
+          case 'outsider_hint':
+            return `[OUTSIDER] ${turn.content}`;
+          case 'insider_guess':
+            return `[INSIDER] Guessed: ${turn.guess}`;
+          case 'ai_analysis':
+            return `[ANALYSIS] Thinking: ${turn.thinking.join(' ')} | Guess: ${turn.guess}`;
         }
       }).join('\n');
 

--- a/backend/openai/types/game.ts
+++ b/backend/openai/types/game.ts
@@ -18,6 +18,7 @@ export const OutsiderTurnSchema = z.object({
     .describe('The hint message from the outsider'),
   turnNumber: z.number().int().positive()
     .describe('Sequential turn number')
+    .optional()
 });
 export type OutsiderTurn = z.infer<typeof OutsiderTurnSchema>;
 
@@ -36,6 +37,7 @@ export const AITurnSchema = z.object({
     .describe('AI\'s guess at the secret word'),
   turnNumber: z.number().int().positive()
     .describe('Sequential turn number')
+    .optional()
 });
 export type AITurn = z.infer<typeof AITurnSchema>;
 
@@ -51,6 +53,7 @@ export const InsiderTurnSchema = z.object({
     .describe('Insider\'s guess attempt'),
   turnNumber: z.number().int().positive()
     .describe('Sequential turn number')
+    .optional()
 });
 export type InsiderTurn = z.infer<typeof InsiderTurnSchema>;
 
@@ -74,13 +77,13 @@ export type Turn = z.infer<typeof TurnSchema>;
  *   gameId: "room123",
  *   conversationHistory: [
  *     // Outsider sends hint
- *     { type: 'outsider_hint', content: "It's red and sweet", turnNumber: 1 },
+ *     { type: 'outsider_hint', content: "It's red and sweet" },
  *     
  *     // AI analyzes and guesses
- *     { type: 'ai_analysis', thinking: ["...", "...", "...", "..."], guess: "cherry", turnNumber: 2 },
+ *     { type: 'ai_analysis', thinking: ["...", "...", "...", "..."], guess: "cherry" },
  *     
  *     // Insider makes wrong guess
- *     { type: 'insider_guess', guess: "apple", turnNumber: 3 }
+ *     { type: 'insider_guess', guess: "apple" }
  *   ]
  * }
  * ```
@@ -91,13 +94,6 @@ export const AnalyzeRequestSchema = z.object({
   
   /** Chronological sequence of turns */
   conversationHistory: z.array(TurnSchema)
-    .refine(
-      (turns) => {
-        // Verify turn numbers are sequential
-        return turns.every((turn, idx) => turn.turnNumber === idx + 1);
-      },
-      { message: "Turn numbers must be sequential starting from 1" }
-    )
     .refine(
       (turns) => {
         // Verify turns alternate correctly: outsider -> ai -> insider -> ai -> outsider -> ...


### PR DESCRIPTION
• Simplified OpenAI service by removing suspicion level and complex role mapping • Made turn numbers optional in preparation for future removal • Updated type definitions to use clear turn types (outsider_hint, ai_analysis, insider_guess) • Maintained turn sequence validation while removing turn number validation • Updated POC and action plan docs to reflect new structure and future tasks • Part of larger effort to simplify game state management