### PR TITLE
Make gameId optional in AnalyzeRequestSchema

### DIFF
--- a/.gc/action-plans/07.09.25-1540-ai-route-cleanup-and-type-harmonization.md
+++ b/.gc/action-plans/07.09.25-1540-ai-route-cleanup-and-type-harmonization.md
@@ -1,0 +1,60 @@
+# AI route cleanup and type harmonization action plan
+
+## Overall goal
+Prepare the codebase for demo-day by simplifying the AI integration:
+• Eliminate duplicate API routes and the `MockAIService`.
+• Make `gameId` optional (roomId already identifies a game).
+• Rename roles **outsider → encoder** and **insider → decoder** across backend & frontend.
+• Keep a single source of truth for the Turn/Zod schemas and share it via imports.
+• Update tests & docs accordingly.
+
+---
+
+## Regression risk analysis
+1. **Compilation failures / missing imports**  
+   Consolidating type definitions or deleting files can break builds.  
+   *Mitigation*: perform global search-replace, run `tsc --noEmit` and existing test suite after each commit.
+
+2. **Runtime 404s** if the front-end or other backend code still hits the deleted route.  
+   *Mitigation*: delete the duplicate router *after* all references are updated; keep route path `/api/ai/analyze` unchanged.
+
+3. **Role name drift between FE & BE** may corrupt game flow.  
+   *Mitigation*: update both store/game logic and backend types in the same PR; add a temporary type union `'encoder' | 'decoder' | 'ai'`.
+
+4. **OpenAI quota / latency** now that all calls hit the real API.  
+   *Mitigation*: keep unit tests offline; integration test is opt-in via env flag (skipped by default).
+
+---
+
+## Action items
+
+| # | Description | Files to modify |
+|---|-------------|----------------|
+|1|**Make `gameId` optional** in the Zod schema.|`backend/openai/types/game.ts`, `backend/src/types/index.ts`, any tests referencing `AnalyzeRequestSchema`.|
+|2|**Role rename**: change literal strings `'outsider_hint'→'encoder_hint'`, `'insider_guess'→'decoder_guess'`, and player roles `'encryptor'→'encoder'`, `'decryptor'→'decoder'`. |All occurrences via global replace. Key files: `backend/openai/types/game.ts`, `backend/src/types/index.ts`, `backend/src/game/*`, socket handlers, `frontend/store/gameStore.ts`, WebSocket handlers, UI components under `frontend/app/*`.|
+|3|**Delete duplicate router** and exports.|Remove `backend/openai/routes/ai.ts`; delete its import in any `index.ts` barrel.|
+|4|**Remove MockAIService**.|Delete `backend/src/ai/mock.ts`; delete instantiation in `backend/src/routes/ai.ts`; update route to import `openAIService` from `backend/openai/services/openai.ts`.|
+|5|**Update main AI route** to call real service and adjust validation (optional `gameId`).|`backend/src/routes/ai.ts`|
+|6|**Consolidate Turn/Zod schemas**: keep canonical definition (current file) and import it everywhere else. Remove secondary re-exports.|Ensure only `backend/openai/types/game.ts` holds the definitions; update import paths in backend & frontend.| 
+|7|**Update tests** for new role names & optional gameId.|All Jest files in `backend/tests` and `frontend/test`.|
+|8|**Create opt-in integration test** (skipped by default).|Add `tests/aiIntegrationReal.test.ts` that is skipped unless `process.env.OPENAI_E2E==='true'`.|
+|9|**Documentation cleanup**.|Update `/backend/ai-api-docs.md` & `/backend/server-spec.md` with the new schema; remove mention of MockAIService.|
+
+---
+
+## Step-by-step instructions
+1. Run a project-wide search-replace for role strings; commit.
+2. Edit `AnalyzeRequestSchema`: change `gameId` → `gameId?: string`.
+3. Refactor imports so every file references `backend/openai/types/game.ts` directly.
+4. Delete `backend/openai/routes/ai.ts`; remove associated export lines.
+5. Delete `backend/src/ai/mock.ts` and its usages.
+6. In `backend/src/routes/ai.ts`:
+   ```ts
+   import { openAIService } from '../../openai/services/openai';
+   // remove MockAIService logic
+   ```
+7. Run `npm test` in both backend & frontend; fix any failures.
+8. Add the skipped integration test (`describe.skip(...)`).
+9. Update documentation; commit with message “AI route clean-up, role rename, type harmonization”.
+
+This plan is self-contained; an agent can tackle each numbered action sequentially. No extra context needed. 

--- a/backend/openai/types/game.ts
+++ b/backend/openai/types/game.ts
@@ -89,7 +89,7 @@ export type Turn = z.infer<typeof TurnSchema>;
  */
 export const AnalyzeRequestSchema = z.object({
   /** Room/session identifier */
-  gameId: z.string(),
+  gameId: z.string().optional(),
 
   /** Chronological sequence of turns */
   conversationHistory: z.array(TurnSchema)

--- a/backend/src/game/state.ts
+++ b/backend/src/game/state.ts
@@ -236,9 +236,9 @@ export class GameStateManager {
     /**
      * Transform conversation history to AnalyzeRequest format
      */
-    public transformToAnalyzeRequest(gameState: GameState, gameId: string): AnalyzeRequest {
+    public transformToAnalyzeRequest(gameState: GameState, gameId?: string): AnalyzeRequest {
         return {
-            gameId,
+            ...(gameId && { gameId }),
             conversationHistory: gameState.conversationHistory
         };
     }

--- a/backend/tests/aiRoutes.test.ts
+++ b/backend/tests/aiRoutes.test.ts
@@ -73,7 +73,7 @@ describe('AI Routes', () => {
             expect(response.body.error).toContain('must be an array');
         });
 
-        it('should return 400 when gameId is missing', async () => {
+        it('should handle request without gameId', async () => {
             const conversationHistory: Turn[] = [
                 {
                     type: 'outsider_hint',
@@ -89,10 +89,11 @@ describe('AI Routes', () => {
             const response = await request(app)
                 .post('/api/ai/analyze')
                 .send(requestBody)
-                .expect(400);
+                .expect(200);
 
-            expect(response.body.success).toBe(false);
-            expect(response.body.error).toContain('gameId is required');
+            expect(response.body.success).toBe(true);
+            expect(response.body.data).toHaveProperty('thinking');
+            expect(response.body.data).toHaveProperty('guess');
         });
 
         it('should validate turn structure correctly', async () => {

--- a/backend/tests/gameState.test.ts
+++ b/backend/tests/gameState.test.ts
@@ -193,7 +193,7 @@ describe('GameStateManager', () => {
     });
 
     describe('transformToAnalyzeRequest', () => {
-        it('should transform game state to analyze request format', () => {
+        it('should transform game state to analyze request format with gameId', () => {
             const gameState = gameStateManager.createGameState('TestWord', []);
             let newGameState = gameStateManager.addOutsiderTurn(gameState, 'First hint');
             newGameState = gameStateManager.addAITurn(newGameState, ['Thought 1', 'Thought 2', 'Thought 3', 'Thought 4'], 'guess1');
@@ -206,6 +206,19 @@ describe('GameStateManager', () => {
             expect(analyzeRequest.conversationHistory[0]?.type).toBe('outsider_hint');
             expect(analyzeRequest.conversationHistory[1]?.type).toBe('ai_analysis');
             expect(analyzeRequest.conversationHistory[2]?.type).toBe('insider_guess');
+        });
+
+        it('should transform game state to analyze request format without gameId', () => {
+            const gameState = gameStateManager.createGameState('TestWord', []);
+            let newGameState = gameStateManager.addOutsiderTurn(gameState, 'First hint');
+            newGameState = gameStateManager.addAITurn(newGameState, ['Thought 1', 'Thought 2', 'Thought 3', 'Thought 4'], 'guess1');
+
+            const analyzeRequest = gameStateManager.transformToAnalyzeRequest(newGameState);
+
+            expect(analyzeRequest.gameId).toBeUndefined();
+            expect(analyzeRequest.conversationHistory).toHaveLength(2);
+            expect(analyzeRequest.conversationHistory[0]?.type).toBe('outsider_hint');
+            expect(analyzeRequest.conversationHistory[1]?.type).toBe('ai_analysis');
         });
     });
 


### PR DESCRIPTION
- Modified AnalyzeRequestSchema to make gameId field optional
- Updated transformToAnalyzeRequest to handle optional gameId parameter
- Simplified request validation by removing unnecessary gameId requirement

Part of AI route cleanup and type harmonization